### PR TITLE
Make link-container a sticky footer

### DIFF
--- a/components/Circle.js
+++ b/components/Circle.js
@@ -8,7 +8,7 @@ const { className, styles } = css.resolve`
     display: block;
     height: 100%;
     width: 100%;
-    margin: 15% auto 0 auto;
+    margin: 0 auto;
   }
 `;
 

--- a/components/CircleAndImages.js
+++ b/components/CircleAndImages.js
@@ -14,24 +14,17 @@ const CircleAndImages = ({ onHelloPage, pageClickedOnce }) => (
         position: relative;
         width: 360px;
         height: 360px;
-        margin: 0 auto;
+        margin: 2.5% auto 0 auto;
       }
 
       @media screen and (min-width: 1270px) {
         .circleAndImages-container {
-          width: 360px;
-          height: 360px;
-        }
-      }
-      
-      @media screen and (min-width: 1400px) {
-        .circleAndImages-container {
-          width: 600px;
-          height: 600px;
+          width: 400px;
+          height: 400px;
         }
       }
 
-      @media screen and (min-width: 1800px) {
+      @media screen and (min-width: 1400px) {
         .circleAndImages-container {
           width: 600px;
           height: 600px;

--- a/components/TitleText.js
+++ b/components/TitleText.js
@@ -8,7 +8,8 @@ const { className, styles } = css.resolve`
     display: block;
     position: relative;
     z-index: 1;
-    width: 100%;
+    padding: 0;
+    margin: 0;
   }
 `;
 
@@ -63,7 +64,9 @@ const TitleText = ({ text, onHelloPage }) => (
         font-family: "Crimson Text", serif;
         font-size: 4em;
         font-weight: 200;
-        margin: -8% 0 0 5%;
+        margin: -2.5% 0 0 5%;
+        padding: 0;
+        line-height: 1em;
       }
 
       @media screen and (min-width: 1270px) {

--- a/pages/index.js
+++ b/pages/index.js
@@ -57,34 +57,38 @@ export default function Home() {
   };
 
   return (
-    <div className="container">
-      <Head>
-        <title>Hi, it's Darren!</title>
-        <link rel="icon" href="/favicon.ico" />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Muli:wght@300&display=swap"
-          rel="stylesheet"
-        />
-      </Head>
+    <>
+      <div className="container">
+        <Head>
+          <title>Hi, it's Darren!</title>
+          <link rel="icon" href="/favicon.ico" />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Muli:wght@300&display=swap"
+            rel="stylesheet"
+          />
+        </Head>
 
-      <TitleText
-        text={text.onHelloPage ? "HELLO" : "ABOUT"}
-        onHelloPage={text.onHelloPage}
-      />
-      <CircleAndImages
-        onHelloPage={text.onHelloPage}
-        pageClickedOnce={text.pageClickedOnce}
-      />
-      <p
-        className={`info-text ${
-          text.onHelloPage && text.pageClickedOnce
-            ? `whiteFlare`
-            : !text.onHelloPage && text.pageClickedOnce
-            ? `whiteFlareAgain`
-            : null
-        }`}
-        dangerouslySetInnerHTML={text.infoText[text.indexToSelect]}
-      ></p>
+        <TitleText
+          text={text.onHelloPage ? "HELLO" : "ABOUT"}
+          onHelloPage={text.onHelloPage}
+        />
+        <CircleAndImages
+          onHelloPage={text.onHelloPage}
+          pageClickedOnce={text.pageClickedOnce}
+        />
+        <p
+          className={`info-text ${
+            text.onHelloPage && text.pageClickedOnce
+              ? `whiteFlare`
+              : !text.onHelloPage && text.pageClickedOnce
+              ? `whiteFlareAgain`
+              : null
+          }`}
+          dangerouslySetInnerHTML={text.infoText[text.indexToSelect]}
+        ></p>
+        {/* push is used to create a sticky footer for link-container to sit on */}
+        <div className="push" />
+      </div>
       <div className="link-container" onClick={() => togglePage()}>
         <PageLink
           text={text.onHelloPage ? "about" : "hello"}
@@ -99,8 +103,9 @@ export default function Home() {
         .container {
           display: block;
           position: relative;
-          margin: 0 auto;
-          height: 100vh;
+          margin: 0 auto -30px auto;
+          padding: 2em 0 0 0;
+          height: 100%;
           max-width: 650px;
           color: white;
         }
@@ -109,9 +114,9 @@ export default function Home() {
           position: absolute;
           left: 0;
           right: 0;
-          margin: 20px auto 0 auto;
+          margin: 2.5% auto 0 auto;
           font-family: "Muli", sans-serif;
-          font-size: 0.925em;
+          font-size: 0.875em;
           font-weight: 400;
           line-height: 1.5em;
           width: 85%;
@@ -119,11 +124,19 @@ export default function Home() {
         }
 
         .link-container {
-          position: absolute;
+          position: relative;
           display: block;
-          bottom: 12.5%;
+          bottom: 0px;
+          margin: 0 auto;
+          left: 0;
           right: 0;
+          max-width: 650px;
+          height: 30px;
           font-size: 0.85em;
+        }
+
+        .push {
+          height: 30px;
         }
 
         .whiteFlare {
@@ -132,18 +145,6 @@ export default function Home() {
 
         .whiteFlareAgain {
           animation: flare-text-white-again 0.5s ease-in-out;
-        }
-
-        @media screen and (min-width: 600px) {
-          .link-container {
-            margin-top: 35%;
-          }
-        }
-
-        @media screen and (min-width: 1270px) {
-          .title {
-            margin: 5%;
-          }
         }
 
         @keyframes flare-text-white {
@@ -172,6 +173,7 @@ export default function Home() {
       `}</style>
 
       <style jsx global>{`
+        #__next,
         html,
         body {
           padding: 0;
@@ -181,6 +183,7 @@ export default function Home() {
             Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue,
             sans-serif;
           overflow: hidden;
+          height: 100%;
         }
         a {
           color: #8affff;
@@ -209,6 +212,6 @@ export default function Home() {
             brightness(99%) contrast(80%);
         }
       `}</style>
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
 ### Purpose
- Get link-container to always sit at bottom of page, and ensure that info-text doesn't flow off the bottom of the page on mobile

### Validating
- All text should show on the page in all contexts and not flow below the page
- Make sure to check animation behavior on page in all contexts to ensure this remains true

### Background context
- This was a pain due to the div #__next not having a height set, which made typical sticky footer techniques not work, once I applied 100% to it, I was able to more easily position elements on the page
- This site is troublesome because the amount of absolute positioning needed to accomplish the animations. Would be worth looking into the possibility of not having to rely on this to make these animations work.

### Follow-on questions
- Is there a better method to do the animations for TitleText.js and .link-container to prevent using so much absolute positioning?

### Extra Release Steps
- none