### PR TITLE
hotfix to ensure text doesn't overflow height on mobile

### DIFF
--- a/components/CircleAndImages.js
+++ b/components/CircleAndImages.js
@@ -14,17 +14,24 @@ const CircleAndImages = ({ onHelloPage, pageClickedOnce }) => (
         position: relative;
         width: 360px;
         height: 360px;
-        margin: 2.5% auto 0 auto;
+        margin: 0 auto;
       }
 
       @media screen and (min-width: 1270px) {
         .circleAndImages-container {
-          width: 400px;
-          height: 400px;
+          width: 360px;
+          height: 360px;
+        }
+      }
+      
+      @media screen and (min-width: 1400px) {
+        .circleAndImages-container {
+          width: 600px;
+          height: 600px;
         }
       }
 
-      @media screen and (min-width: 1400px) {
+      @media screen and (min-width: 1800px) {
         .circleAndImages-container {
           width: 600px;
           height: 600px;

--- a/components/TitleText.js
+++ b/components/TitleText.js
@@ -64,7 +64,7 @@ const TitleText = ({ text, onHelloPage }) => (
         font-family: "Crimson Text", serif;
         font-size: 4em;
         font-weight: 200;
-        margin: -2.5% 0 0 5%;
+        margin: -5% 0 0 5%;
         padding: 0;
         line-height: 1em;
       }

--- a/pages/index.js
+++ b/pages/index.js
@@ -104,7 +104,7 @@ export default function Home() {
           display: block;
           position: relative;
           margin: 0 auto -30px auto;
-          padding: 2em 0 0 0;
+          padding: 1em 0 0 0;
           height: 100%;
           max-width: 650px;
           color: white;
@@ -145,6 +145,12 @@ export default function Home() {
 
         .whiteFlareAgain {
           animation: flare-text-white-again 0.5s ease-in-out;
+        }
+
+        @media screen and (min-width: 1270px) {
+          .container {
+            padding: 2em 0 0 0;
+          }
         }
 
         @keyframes flare-text-white {


### PR DESCRIPTION
 ### Purpose
- Text still overflowing mobile height, so needed to adjust top-margin and padding for .container, TitleText.js and CircleAndImages.js to give it more room on screen


### Validating
- .info-text and .link-container should not overlap on mobile
- .info-text should not overflow below the fold on mobile


### Background context
- Despite chrome devtools showing that text appeared as desired, after launching and checking on a mobile device this wasn't the case

### Follow-on questions
- Need a better workflow to ensure that apps look correct before deploying


### Extra Release Steps
- none