### PR TITLE
Third attempt hot fixing text overflowing onto itself

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -21,8 +21,8 @@ export default function Home() {
           designing and wireframing to getting code on servers so users can see
           their stuff. I recently expanded my skills with React, Redux, Node.js,
           MongoDB, and other fun things.</p>
-          <a href="mailto:darren.bridenbeck@gmail.com">Send me an email</a> if
-          you’d like to work together.
+          <p> <a href="mailto:darren.bridenbeck@gmail.com">Send me an email</a> if
+          you’d like to work together. </p>
           <p>Check out my latest project for <a href="http://whidbeyherbal.com">Whidbey Herbal</a>.</p>
         `,
       },
@@ -67,7 +67,7 @@ export default function Home() {
           onHelloPage={text.onHelloPage}
           pageClickedOnce={text.pageClickedOnce}
         />
-        <p
+        <div
           className={`info-text ${
             text.onHelloPage && text.pageClickedOnce
               ? `whiteFlare`
@@ -76,7 +76,7 @@ export default function Home() {
               : null
           }`}
           dangerouslySetInnerHTML={text.infoText[text.indexToSelect]}
-        ></p>
+        ></div>
         {/* push is used to create a sticky footer for link-container to sit on */}
         <div className="push" />
       </div>
@@ -105,7 +105,7 @@ export default function Home() {
           position: absolute;
           left: 0;
           right: 0;
-          margin: 0% auto;
+          margin: -10px auto 0 auto;
           font-family: "Muli", sans-serif;
           font-size: 0.875em;
           font-weight: 400;


### PR DESCRIPTION
 ### Purpose
- Get text to not exceed bottom fold on mobile, not to overlap info-text with link-container

### Validating
- Text should remain within mobile browser window and not overlap itself


### Background context
- This is awful - dev chrome tools shows mobile looks fine, but when viewing on an actual device there's issue with text overlapping
- Additionally, adjusted .info-text to be a div instead of p, that way the <p>'s within text.infoText would render on initial load

### Follow-on questions
- Have got to figure out a better workflow for developing for mobile accurately. I feel like the original sin here has got to be all the absolute positioning that's going on, but still, there needs to be a better process

### Extra Release Steps
- pray to god that this works ;)