### PR TITLE
reset .info-text margin to 0 auto when on laptop+ devices

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -144,6 +144,7 @@ export default function Home() {
           }
           .info-text {
             width: 80%;
+            margin: 0 auto;
           }
         }
 


### PR DESCRIPTION
title says it all. yet another hotfix