### PR TITLE
add max-height and max-width to CircleAndImages.js

### DIFF
--- a/components/CircleAndImages.js
+++ b/components/CircleAndImages.js
@@ -14,6 +14,8 @@ const CircleAndImages = ({ onHelloPage, pageClickedOnce }) => (
         position: relative;
         width: 360px;
         height: 360px;
+        max-width: 50vh;
+        max-height: 50vh;
         margin: 0 auto;
       }
 
@@ -23,7 +25,7 @@ const CircleAndImages = ({ onHelloPage, pageClickedOnce }) => (
           height: 400px;
         }
       }
-      
+
       @media screen and (min-width: 1400px) {
         .circleAndImages-container {
           width: 600px;

--- a/components/CircleAndImages.js
+++ b/components/CircleAndImages.js
@@ -23,6 +23,8 @@ const CircleAndImages = ({ onHelloPage, pageClickedOnce }) => (
         .circleAndImages-container {
           width: 400px;
           height: 400px;
+          max-width: 400px;
+          max-height: 400px;
         }
       }
 
@@ -30,13 +32,8 @@ const CircleAndImages = ({ onHelloPage, pageClickedOnce }) => (
         .circleAndImages-container {
           width: 600px;
           height: 600px;
-        }
-      }
-
-      @media screen and (min-width: 1800px) {
-        .circleAndImages-container {
-          width: 600px;
-          height: 600px;
+          max-width: 600px;
+          max-height: 600px;
         }
       }
     `}</style>


### PR DESCRIPTION
 ### Purpose
- prevent CircleAndImages from ever growing so large that it would push text below fold on mobile

### Validating
- mobile devices should always be able to see all of the text

### Background context
- users were reporting that info-text was overflowing the fold

### Follow-on questions
none

### Extra Release Steps
- none