### PR TITLE
Apply flexbox to index.js

### DIFF
--- a/components/TitleCircleImages.js
+++ b/components/TitleCircleImages.js
@@ -1,0 +1,17 @@
+import TitleText from "./TitleText";
+import CircleAndImages from "./CircleAndImages";
+
+export default function TitleCircleImages({titleText, onHelloPage, pageClickedOnce}) {
+  return (
+    <>
+      <TitleText
+        titleText={titleText}
+        onHelloPage={onHelloPage}
+      />
+      <CircleAndImages
+        onHelloPage={onHelloPage}
+        pageClickedOnce={pageClickedOnce}
+      />
+    </>
+  );
+}

--- a/components/TitleText.js
+++ b/components/TitleText.js
@@ -19,7 +19,7 @@ const variants = {
   moveRight: { opacity: 0, y: "-100px", x: "0px" },
 };
 
-const TitleText = ({ text, onHelloPage }) => (
+const TitleText = ({ titleText, onHelloPage }) => (
   <>
     <Head>
       <link
@@ -37,7 +37,7 @@ const TitleText = ({ text, onHelloPage }) => (
           transition={{ duration: 1 }}
           variants={variants}
         >
-          <h1 className="title blue">{text}</h1>
+          <h1 className="title blue">{titleText}</h1>
           {styles}
         </motion.div>
       )}
@@ -52,7 +52,7 @@ const TitleText = ({ text, onHelloPage }) => (
           transition={{ duration: 1 }}
           variants={variants}
         >
-          <h1 className="title red">{text}</h1>
+          <h1 className="title red">{titleText}</h1>
           {styles}
         </motion.div>
       )}

--- a/pages/index.js
+++ b/pages/index.js
@@ -88,16 +88,15 @@ export default function Home() {
           }`}
           dangerouslySetInnerHTML={text.infoText[text.indexToSelect]}
         ></div>
-        {/* push is used to create a sticky footer for link-container to sit on */}
         <div className="push" />
       </div>
       <div className="link-container" onClick={() => togglePage()}>
         <PageLink
-          text={text.onHelloPage ? "about" : "hello"}
+          text={text.title[text.indexToSelect].toLowerCase()}
           onHelloPage={text.onHelloPage}
         />
         <PageArrow
-          text={text.onHelloPage ? "about" : "hello"}
+          text={text.title[text.indexToSelect].toLowerCase()}
           onHelloPage={text.onHelloPage}
         />
       </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,10 +2,7 @@ import Head from 'next/head'
 import { useState } from 'react';
 import PageLink from '../components/PageLink';
 import PageArrow from '../components/PageArrow';
-import TitleText from '../components/TitleText';
 import TitleCircleImages from '../components/TitleCircleImages';
-
-import CircleAndImages from '../components/CircleAndImages';
 
 export default function Home() {
 
@@ -74,10 +71,6 @@ export default function Home() {
           href="https://fonts.googleapis.com/css2?family=Muli:wght@300&display=swap"
           rel="stylesheet"
         />
-        <link rel="preload" as="image" href="/images/computer.png" />
-        <link rel="preload" as="image" href="/images/pinball.png" />
-        <link rel="preload" as="image" href="/images/phone.png" />
-        <link rel="preload" as="image" href="/images/rollerskate.png" />
       </Head>
       <div className="container">
         <TitleCircleImages 

--- a/pages/index.js
+++ b/pages/index.js
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import PageLink from '../components/PageLink';
 import PageArrow from '../components/PageArrow';
 import TitleText from '../components/TitleText';
+import TitleCircleImages from '../components/TitleCircleImages';
 
 import CircleAndImages from '../components/CircleAndImages';
 
@@ -49,43 +50,39 @@ export default function Home() {
 
   return (
     <>
-      <div className="container">
-        <Head>
-          <title>I'm Darren!</title>
-          <link
-            rel="apple-touch-icon"
-            sizes="180x180"
-            href="/images/apple-touch-icon.png"
-          />
-          <link
-            rel="icon"
-            type="image/png"
-            sizes="32x32"
-            href="/images/favicon-32x32.png"
-          />
-          <link
-            rel="icon"
-            type="image/png"
-            sizes="16x16"
-            href="/images/favicon-16x16.png"
-          />
-          <link rel="manifest" href="/site.webmanifest" />
-          <link
-            href="https://fonts.googleapis.com/css2?family=Muli:wght@300&display=swap"
-            rel="stylesheet"
-          />
-          <link rel="preload" as="image" href="/images/computer.png" />
-          <link rel="preload" as="image" href="/images/pinball.png" />
-          <link rel="preload" as="image" href="/images/phone.png" />
-          <link rel="preload" as="image" href="/images/rollerskate.png" />
-        </Head>
-
-        <TitleText
-          text={text.onHelloPage ? "HELLO" : "ABOUT"}
-          onHelloPage={text.onHelloPage}
+      <Head>
+        <title>I'm Darren!</title>
+        <link
+          rel="apple-touch-icon"
+          sizes="180x180"
+          href="/images/apple-touch-icon.png"
         />
-        <CircleAndImages
-          onHelloPage={text.onHelloPage}
+        <link
+          rel="icon"
+          type="image/png"
+          sizes="32x32"
+          href="/images/favicon-32x32.png"
+        />
+        <link
+          rel="icon"
+          type="image/png"
+          sizes="16x16"
+          href="/images/favicon-16x16.png"
+        />
+        <link rel="manifest" href="/site.webmanifest" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Muli:wght@300&display=swap"
+          rel="stylesheet"
+        />
+        <link rel="preload" as="image" href="/images/computer.png" />
+        <link rel="preload" as="image" href="/images/pinball.png" />
+        <link rel="preload" as="image" href="/images/phone.png" />
+        <link rel="preload" as="image" href="/images/rollerskate.png" />
+      </Head>
+      <div className="container">
+        <TitleCircleImages 
+          titleText={text.title[text.indexToSelect]} 
+          onHelloPage={text.onHelloPage} 
           pageClickedOnce={text.pageClickedOnce}
         />
         <div
@@ -113,7 +110,9 @@ export default function Home() {
       </div>
       <style jsx>{`
         .container {
-          display: block;
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
           position: relative;
           margin: 0 auto -30px auto;
           padding: 1em 0 0 0;
@@ -123,10 +122,10 @@ export default function Home() {
         }
 
         .info-text {
-          position: absolute;
+          position: relative;
           left: 0;
           right: 0;
-          margin: -10px auto 0 auto;
+          margin: 10px auto 0 auto;
           font-family: "Muli", sans-serif;
           font-size: 0.75em;
           font-weight: 400;


### PR DESCRIPTION
 ### Purpose
- Center Title, Circle, Images and Info-text on mobile devices

### Validating
- On mobile, Title, Circle, Images and Info-text should be centered on the page instead of at the top
- Laptop and large screen resolutions should be unaffected

### Background context
- Some users had experiences where there was a large space between info-text and link-container, which I'd like to have split with the top of the window if possible

### Follow-on questions
- Need to double check with users who have mobile devices that were previously experiencing text overlap to ensure that this fix doesn't re-create that same issue.

### Extra Release Steps
- none