### PR TITLE
stop circle border-radius from animating on load

### DIFF
--- a/components/CircleAndImages/Circle.tsx
+++ b/components/CircleAndImages/Circle.tsx
@@ -8,7 +8,7 @@ const StyledCircle = styled.div`
   width: 100%;
   margin: 0 auto;
   border-radius: 50%;
-  transition: all 0.3s;
+  transition: background-color 0.3s;
   background-color: ${({ color }) => (color === "red" ? "#d13b40" : "#3bc9d1")};
 `;
 


### PR DESCRIPTION
Hotfix to hopefully prevent circle from animating on load. This only happens when hosted live, not on development server. so it might have to do something with SSR or static rendered pages with next, if this doesn't work.