### PR TITLE
Prevent image filter transition on load

### DIFF
--- a/components/ImageComponents/ComputerImage.tsx
+++ b/components/ImageComponents/ComputerImage.tsx
@@ -21,11 +21,14 @@ const StyledComputerImage = styled.img`
   width: 55%;
   animation: ${rotate} 90s infinite linear;
   animation-delay: 200ms;
-  transition: filter 0.5s;
-  filter: ${({currentPage}) => triggerFilter(currentPage)};
+  transition: ${({ pageClickedOnce }) => pageClickedOnce ? "filter 0.5s" : ""};
+  filter: ${({ currentPage }) => triggerFilter(currentPage)};
 `;
 
-const ComputerImage: React.FC<ImageModel> = ({ currentPage }) =>
+const ComputerImage: React.FC<ImageModel> = ({
+  currentPage,
+  pageClickedOnce,
+}) => (
   <picture>
     <source
       srcSet={require("../../public/images/computer.png?webp")}
@@ -37,9 +40,11 @@ const ComputerImage: React.FC<ImageModel> = ({ currentPage }) =>
     />
     <StyledComputerImage
       currentPage={currentPage}
+      pageClickedOnce={pageClickedOnce}
       srcSet={require("../../public/images/computer.png")}
       alt="An open laptop"
     />
   </picture>
+);
 
 export default ComputerImage;

--- a/components/ImageComponents/ImagePairs.tsx
+++ b/components/ImageComponents/ImagePairs.tsx
@@ -7,9 +7,14 @@ import ImageAnimation from "../../animations/ImageAnimation";
 interface ImagesProps {
   leftOriented: boolean;
   currentPage: string;
+  pageClickedOnce: boolean;
 }
 
-const Images: React.FC<ImagesProps> = ({ leftOriented, currentPage }) => {
+const Images: React.FC<ImagesProps> = ({
+  leftOriented,
+  currentPage,
+  pageClickedOnce,
+}) => {
   const helloImageConfig = {
     initial: "flyIn",
     animate: currentPage === "HELLO" ? "center" : "flyOut",
@@ -28,9 +33,15 @@ const Images: React.FC<ImagesProps> = ({ leftOriented, currentPage }) => {
         leftOriented={leftOriented}
       >
         {leftOriented ? (
-          <ComputerImage currentPage={currentPage} />
+          <ComputerImage
+            currentPage={currentPage}
+            pageClickedOnce={pageClickedOnce}
+          />
         ) : (
-          <PhoneImage currentPage={currentPage} />
+          <PhoneImage
+            currentPage={currentPage}
+            pageClickedOnce={pageClickedOnce}
+          />
         )}
       </ImageAnimation>
 
@@ -40,9 +51,15 @@ const Images: React.FC<ImagesProps> = ({ leftOriented, currentPage }) => {
         leftOriented={leftOriented}
       >
         {leftOriented ? (
-          <PinballImage currentPage={currentPage} />
+          <PinballImage
+            currentPage={currentPage}
+            pageClickedOnce={pageClickedOnce}
+          />
         ) : (
-          <RollerskateImage currentPage={currentPage} />
+          <RollerskateImage
+            currentPage={currentPage}
+            pageClickedOnce={pageClickedOnce}
+          />
         )}
       </ImageAnimation>
     </>

--- a/components/ImageComponents/PhoneImage.tsx
+++ b/components/ImageComponents/PhoneImage.tsx
@@ -22,11 +22,12 @@ const StyledPhoneImage = styled.img`
   height: auto;
   animation: ${rotate} 90s infinite linear;
   animation-delay: 300ms;
-  transition: filter 0.5s;
+  transition: ${({ pageClickedOnce }) =>
+    pageClickedOnce ? "filter 0.5s" : ""};
   filter: ${({ currentPage }) => triggerFilter(currentPage)};
 `;
 
-const PhoneImage: React.FC<ImageModel> = ({ currentPage }) =>
+const PhoneImage: React.FC<ImageModel> = ({ currentPage, pageClickedOnce }) => (
   <picture>
     <source
       srcSet={require("../../public/images/phone.png?webp")}
@@ -38,9 +39,11 @@ const PhoneImage: React.FC<ImageModel> = ({ currentPage }) =>
     />
     <StyledPhoneImage
       currentPage={currentPage}
+      pageClickedOnce={pageClickedOnce}
       srcSet={require("../../public/images/phone.png")}
       alt="An 80's style mobile phone"
     />
   </picture>
+);
 
 export default PhoneImage;

--- a/components/ImageComponents/PinballImage.tsx
+++ b/components/ImageComponents/PinballImage.tsx
@@ -21,11 +21,15 @@ const StyledPinballImage = styled.img`
   width: 40%;
   animation: ${rotate} 80s infinite linear;
   animation-delay: 100ms;
-  transition: filter 0.5s;
+  transition: ${({ pageClickedOnce }) =>
+    pageClickedOnce ? "filter 0.5s" : ""};
   filter: ${({ currentPage }) => triggerFilter(currentPage)};
 `;
 
-const PinballImage: React.FC<ImageModel> = ({ currentPage }) => 
+const PinballImage: React.FC<ImageModel> = ({
+  currentPage,
+  pageClickedOnce,
+}) => (
   <picture>
     <source
       srcSet={require("../../public/images/pinball.png?webp")}
@@ -37,9 +41,11 @@ const PinballImage: React.FC<ImageModel> = ({ currentPage }) =>
     />
     <StyledPinballImage
       currentPage={currentPage}
+      pageClickedOnce={pageClickedOnce}
       srcSet={require("../../public/images/pinball.png")}
       alt="A pinball table"
     />
   </picture>
+);
 
 export default PinballImage;

--- a/components/ImageComponents/RollerskateImage.tsx
+++ b/components/ImageComponents/RollerskateImage.tsx
@@ -21,11 +21,12 @@ const StyledRollerskateImage = styled.img`
   width: 45%;
   animation: ${rotate} 80s infinite linear;
   animation-delay: 400ms;
-  transition: filter 0.5s;
+  transition: ${({ pageClickedOnce }) =>
+    pageClickedOnce ? "filter 0.5s" : ""};
   filter: ${({ currentPage }) => triggerFilter(currentPage)};
 `;
 
-const RollerskateImage: React.FC<ImageModel> = ({ currentPage }) =>
+const RollerskateImage: React.FC<ImageModel> = ({ currentPage, pageClickedOnce }) =>
   <picture>
     <source
       srcSet={require("../../public/images/rollerskate.png?webp")}
@@ -37,6 +38,7 @@ const RollerskateImage: React.FC<ImageModel> = ({ currentPage }) =>
     />
     <StyledRollerskateImage
       currentPage={currentPage}
+      pageClickedOnce={pageClickedOnce}
       src={require("../../public/images/rollerskate.png")}
       alt="A quad rollerskate"
     />

--- a/models/images.ts
+++ b/models/images.ts
@@ -1,3 +1,4 @@
 export default interface ImageModel {
   currentPage: string;
+  pageClickedOnce: boolean;
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -85,9 +85,7 @@ export default function Home() {
       </Head>
       <Layout>
         <MainContent>
-          <TitleText
-            currentPage={appState.currentPage}
-          />
+          <TitleText currentPage={appState.currentPage} />
           <CircleContainer
             currentPage={appState.currentPage}
             pageClickedOnce={appState.pageClickedOnce}
@@ -96,16 +94,22 @@ export default function Home() {
               if current route is not porfolio show images, otherwise show
               component that renders projects that are selected
             */}
-            <ImagePairs leftOriented={true} currentPage={appState.currentPage} />
-            <ImagePairs leftOriented={false} currentPage={appState.currentPage} />
+            <ImagePairs
+              leftOriented={true}
+              currentPage={appState.currentPage}
+              pageClickedOnce={appState.pageClickedOnce}
+            />
+            <ImagePairs
+              leftOriented={false}
+              currentPage={appState.currentPage}
+              pageClickedOnce={appState.pageClickedOnce}
+            />
           </CircleContainer>
           {/* 
             if current route is not portfolio show InfoText otherwise show
             projects div
           */}
-          <InfoText
-            infoText={appState.infoText[appState.currentPage]}
-          />
+          <InfoText infoText={appState.infoText[appState.currentPage]} />
         </MainContent>
         <PageLinkContainer
           currentPage={appState.currentPage}


### PR DESCRIPTION
### Purpose
- prevent images filter being transitioned on page load

### Validation
- on initial page load, images should not have a filter transition, they should simply appear with the rest of the page

### Background Context
- Having the images transition on load looks a bit funny - if the entire page faded in it would make more sense, but currently it looks more like a bug

### Additional Questions
- the ImageComponents folder could use some refactoring. Perhaps using a HOC instead of four individual image components with nearly identical info