### PR TITLE
Increase nav height

### DIFF
--- a/components/CircleContainer/index.tsx
+++ b/components/CircleContainer/index.tsx
@@ -12,17 +12,17 @@ const CircleContainerDiv = styled.div`
   margin: 0 auto;
 
   @media screen and (min-width: 1270px) {
-    width: 400px;
-    height: 400px;
-    max-width: 400px;
-    max-height: 400px;
+    width: 375px;
+    height: 375px;
+    max-width: 375px;
+    max-height: 375px;
   }
 
   @media screen and (min-width: 1400px) {
-    width: 600px;
-    height: 600px;
-    max-width: 600px;
-    max-height: 600px;
+    width: 575px;
+    height: 575px;
+    max-width: 575px;
+    max-height: 575px;
   }
 `;
 

--- a/components/InfoText.tsx
+++ b/components/InfoText.tsx
@@ -18,7 +18,7 @@ const InfoTextContainer = styled.div`
     width: 80%;
     margin: 0 auto;
     font-size: 0.875rem;
-    height: 33vh;
+    height: 30vh;
   }
   @media screen and (min-width: 1400px) {
     width: 80%;

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -10,10 +10,6 @@ const StyledLayout = styled.div`
   height: 100%;
   max-width: 650px;
   color: white;
-
-  @media screen and (min-width: 1270px) {
-    padding: 2em 0 0 0;
-  }
 `;
 
 interface LayoutProps {

--- a/components/PageLinkContainer/index.tsx
+++ b/components/PageLinkContainer/index.tsx
@@ -4,12 +4,12 @@ import PageLink from "./PageLink";
 const LinkContainer = styled.div`
   position: relative;
   display: flex;
-  flex-grow: 0;
+  flex-grow: 1;
   justify-content: space-evenly;
-  align-content: center;
+  align-items: center;
   margin: 0 auto;
   width: 100%;
-  height: 3%;
+  height: 4%;
   font-size: 0.85em;
   z-index: 99;
 `;

--- a/components/TitleText.tsx
+++ b/components/TitleText.tsx
@@ -5,8 +5,7 @@ import TitleAnimation from "../animations/TitleAnimation";
 
 const Title = styled.h1`
   position: absolute;
-  margin-top: ${({ currentPage }) =>
-    currentPage === "PORTFOLIO" ? "-0.325em" : "-.325em"};
+  margin-top: -0.325em;
   margin-left: ${({ currentPage }) =>
     currentPage === "PORTFOLIO" ? "0" : "2.5%"};
   padding: 0;

--- a/components/TitleText.tsx
+++ b/components/TitleText.tsx
@@ -6,7 +6,7 @@ import TitleAnimation from "../animations/TitleAnimation";
 const Title = styled.h1`
   position: absolute;
   margin-top: ${({ currentPage }) =>
-    currentPage === "PORTFOLIO" ? "-0.5em" : "-.325em"};
+    currentPage === "PORTFOLIO" ? "-0.325em" : "-.325em"};
   margin-left: ${({ currentPage }) =>
     currentPage === "PORTFOLIO" ? "0" : "2.5%"};
   padding: 0;
@@ -25,7 +25,7 @@ const Title = styled.h1`
 
 const SubTitle = styled.h2`
   position: absolute;
-  margin-top: 0.5em;
+  margin-top: .825em;
   color: #ffff8a;
   font-weight: bold;
   font-size: 1.5em;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -30,12 +30,12 @@ export default function Home() {
         color: "#3bc9d1",
       },
       {
-        pageName: "ABOUT",
-        color: "#d13b40",
-      },
-      {
         pageName: "PORTFOLIO",
         color: "#ffff8a",
+      },
+      {
+        pageName: "ABOUT",
+        color: "#d13b40",
       },
     ],
     infoText: {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,7 +12,7 @@ import AppStateModel from "../models/appState";
 const MainContent = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: space-between;
   flex-grow: 1;
   align-self: center;
   width: 100%;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,7 +12,7 @@ import AppStateModel from "../models/appState";
 const MainContent = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: center;
   flex-grow: 1;
   align-self: center;
   width: 100%;


### PR DESCRIPTION
### Purpose
- Give nav more room to make it easier to click links

### Validating
- On large screen, laptop, and mobile devices everything should stay within viewport height
- Portfolios should expand and not clip their content in all devices

### Background context
- The navlinks were too close to bottom of the window which sometimes toggled Mac's toolbar if you weren't careful, which made for a bad UX

### Follow-on questions
- Wondering if the nav itself isn't that user friendly - is it clear enough that these are links? This unconventional layout might be challenging for users to understand

### Extra Release Steps
- none