### PR TITLE
Portfolio initial animation hotfix

### DIFF
--- a/components/ImageComponents/ComputerImage.tsx
+++ b/components/ImageComponents/ComputerImage.tsx
@@ -21,10 +21,9 @@ const StyledComputerImage = styled.img`
   width: 55%;
   animation: ${rotate} 90s infinite linear;
   animation-delay: 200ms;
-  transition: ${({ pageClickedOnce }) =>
-    pageClickedOnce ? "filter 0.5s" : ""};
   filter: ${({ currentPage, projectHoveredIndex }) =>
     triggerFilter(currentPage, projectHoveredIndex)};
+  transition: filter 2s; 
 `;
 
 const ComputerImage: React.FC<ImageModel> = ({

--- a/components/ImageComponents/PhoneImage.tsx
+++ b/components/ImageComponents/PhoneImage.tsx
@@ -22,8 +22,7 @@ const StyledPhoneImage = styled.img`
   height: auto;
   animation: ${rotate} 90s infinite linear;
   animation-delay: 300ms;
-  transition: ${({ pageClickedOnce }) =>
-    pageClickedOnce ? "filter 0.5s" : ""};
+  transition: filter 2s;
   filter: ${({ currentPage, projectHoveredIndex }) =>
     triggerFilter(currentPage, projectHoveredIndex)};
 `;

--- a/components/ImageComponents/PinballImage.tsx
+++ b/components/ImageComponents/PinballImage.tsx
@@ -21,8 +21,7 @@ const StyledPinballImage = styled.img`
   width: 40%;
   animation: ${rotate} 80s infinite linear;
   animation-delay: 100ms;
-  transition: ${({ pageClickedOnce }) =>
-    pageClickedOnce ? "filter 0.5s" : ""};
+  transition: filter 2s;
   filter: ${({ currentPage, projectHoveredIndex }) =>
     triggerFilter(currentPage, projectHoveredIndex)};
 `;

--- a/components/ImageComponents/RollerskateImage.tsx
+++ b/components/ImageComponents/RollerskateImage.tsx
@@ -21,8 +21,7 @@ const StyledRollerskateImage = styled.img`
   width: 45%;
   animation: ${rotate} 80s infinite linear;
   animation-delay: 400ms;
-  transition: ${({ pageClickedOnce }) =>
-    pageClickedOnce ? "filter 0.5s" : ""};
+  transition: filter 2s;
   filter: ${({ currentPage, projectHoveredIndex }) =>
     triggerFilter(currentPage, projectHoveredIndex)};
 `;

--- a/components/InfoText.tsx
+++ b/components/InfoText.tsx
@@ -18,13 +18,13 @@ const InfoTextContainer = styled.div`
     width: 80%;
     margin: 0 auto;
     font-size: 0.875rem;
-    height: 30vh;
+    height: 37vh;
   }
   @media screen and (min-width: 1400px) {
     width: 80%;
     margin: 0 auto;
     font-size: 0.875rem;
-    height: 30vh;
+    height: 35vh;
   }
 `;
 

--- a/components/PageLinkContainer/index.tsx
+++ b/components/PageLinkContainer/index.tsx
@@ -9,9 +9,11 @@ const LinkContainer = styled.div`
   align-items: center;
   margin: 0 auto;
   width: 100%;
-  height: 4%;
+  height: 100%;
+  max-height: 45px;
   font-size: 0.85em;
   z-index: 99;
+  border: 1px solid blue;
 `;
 
 interface PageLinkContainerProps {

--- a/components/PageLinkContainer/index.tsx
+++ b/components/PageLinkContainer/index.tsx
@@ -13,7 +13,6 @@ const LinkContainer = styled.div`
   max-height: 45px;
   font-size: 0.85em;
   z-index: 99;
-  border: 1px solid blue;
 `;
 
 interface PageLinkContainerProps {

--- a/components/ProjectTiles.tsx
+++ b/components/ProjectTiles.tsx
@@ -1,44 +1,6 @@
 import { motion, AnimatePresence } from "framer-motion";
-import styled, { keyframes, css } from "styled-components";
+import styled from "styled-components";
 import { ProjectModel } from "../models/appState";
-
-const fadeIn = keyframes`
-  0% {
-    opacity: 0;
-    height: 0;
-  }
-  50% {
-    opacity: 0;
-  }
-  100% {
-    height: 100%;
-    opacity: 1;
-  }
-`;
-
-const fadeOut = keyframes`
-  0% {
-    opacity: 1;
-    height: 100%;
-  }
-  50% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 0;
-    height: 0%;
-  }
-`;
-
-const fadeInAnimation = () =>
-  css`
-    animation: ${fadeIn} 0.75s ease-in-out forwards;
-  `;
-
-const fadeOutAnimation = () =>
-  css`
-    animation: ${fadeOut} 0.75s ease-in-out forwards;
-  `;
 
 const projectVariants = {
   initial: {
@@ -54,9 +16,9 @@ const projectVariants = {
     border: "2px solid red",
   },
   collapsed: {
-    height: "15%",
+    height: "10%",
     padding: "1.5% 2.5%",
-    margin: "2% 2.5%",
+    margin: "1% 2.5%",
     border: "2px solid green",
   },
 };
@@ -81,6 +43,7 @@ const ProjectsContainer = styled.div`
   flex-direction: column;
   justify-content: space-evenly;
   height: 100%;
+  border: 1px solid red;
 `;
 
 const Project = styled(motion.div)`

--- a/components/ProjectTiles.tsx
+++ b/components/ProjectTiles.tsx
@@ -7,19 +7,19 @@ const projectVariants = {
     height: "20%",
     padding: "2.5% 2.5%",
     margin: "2.5% 2.5%",
-    border: "2px solid green",
+    border: "2px solid #3BC9D1",
   },
-  expanded: {
+  expanded: (color) => ({
     height: "60%",
     padding: "0% 2.5%",
     margin: "0% 2.5%",
-    border: "2px solid red",
-  },
+    border: `2px solid ${color}`,
+  }),
   collapsed: {
     height: "10%",
     padding: "0 2.5%",
     margin: "1% 2.5%",
-    border: "2px solid green",
+    border: "2px solid #3BC9D1",
   },
 };
 
@@ -117,16 +117,13 @@ const ProjectTiles: React.FC<ProjectTilesProps> = ({
   <ProjectsContainer>
     {projects.map((project: ProjectModel, index: number) => {
       const isProjectHovered = projectHoveredIndex === index;
-      // look into useCallback! and useMemo! look at formatOnSave and add esLint!
       const updateProjectHoverIndex = () => handleProjectHover(index);
       return (
         <Project
           key={project.url}
           onClick={updateProjectHoverIndex}
-          isProjectHovered={isProjectHovered}
-          projectHoveredIndex={projectHoveredIndex}
-          color={project.color}
           initial="initial"
+          custom={project.color}
           variants={projectVariants}
           animate={
             isProjectHovered

--- a/components/ProjectTiles.tsx
+++ b/components/ProjectTiles.tsx
@@ -10,14 +10,14 @@ const projectVariants = {
     border: "2px solid green",
   },
   expanded: {
-    height: "70%",
+    height: "60%",
     padding: "0% 2.5%",
     margin: "0% 2.5%",
     border: "2px solid red",
   },
   collapsed: {
     height: "10%",
-    padding: "1.5% 2.5%",
+    padding: "0 2.5%",
     margin: "1% 2.5%",
     border: "2px solid green",
   },
@@ -43,7 +43,6 @@ const ProjectsContainer = styled.div`
   flex-direction: column;
   justify-content: space-evenly;
   height: 100%;
-  border: 1px solid red;
 `;
 
 const Project = styled(motion.div)`
@@ -76,6 +75,7 @@ const ProjectInfoContainer = styled(motion.div)`
   display: flex;
   flex-direction: column;
   justify-content: space-evenly;
+  overflow: hidden;
   margin: 0;
 `;
 

--- a/components/ProjectTiles.tsx
+++ b/components/ProjectTiles.tsx
@@ -1,3 +1,4 @@
+import { motion, AnimatePresence } from "framer-motion";
 import styled, { keyframes, css } from "styled-components";
 import { ProjectModel } from "../models/appState";
 
@@ -39,6 +40,42 @@ const fadeOutAnimation = () =>
     animation: ${fadeOut} 0.75s ease-in-out forwards;
   `;
 
+const projectVariants = {
+  initial: {
+    height: "20%",
+    padding: "2.5% 2.5%",
+    margin: "2.5% 2.5%",
+    border: "2px solid green",
+  },
+  expanded: {
+    height: "70%",
+    padding: "0% 2.5%",
+    margin: "0% 2.5%",
+    border: "2px solid red",
+  },
+  collapsed: {
+    height: "15%",
+    padding: "1.5% 2.5%",
+    margin: "2% 2.5%",
+    border: "2px solid green",
+  },
+};
+
+const infoContainerVariants = {
+  initial: {
+    opacity: 0,
+    height: "0%"
+  },
+  animate: {
+    opacity: 1,
+    height: "100%",
+  },
+  exit: {
+    opacity: 0,
+    height: "0%",
+  }
+}
+
 const ProjectsContainer = styled.div`
   display: flex;
   flex-direction: column;
@@ -46,22 +83,12 @@ const ProjectsContainer = styled.div`
   height: 100%;
 `;
 
-const Project = styled.div`
+const Project = styled(motion.div)`
   display: flex;
   flex-direction: column;
-  height: ${({ isProjectHovered, projectHoveredIndex }) =>
-    isProjectHovered ? "70%" : projectHoveredIndex === -1 ? "4em" : "1.825em"};
-  padding: ${({ isProjectHovered, projectHoveredIndex }) =>
-    isProjectHovered
-      ? "0 2.5%"
-      : projectHoveredIndex === -1
-      ? "1em"
-      : "0 2.5%"};
-  margin: 0.5% 2.5%;
-  justify-content: flex-start;
-  border: ${({ isProjectHovered, color }) =>
-    isProjectHovered ? `2px solid ${color}` : `2px solid #3bc9d1`};
-  transition: all 0.75s ease-in-out;
+  justify-content: center;
+  padding: 2.5%;
+  margin: 2.5%;
   overflow: hidden;
 `;
 
@@ -82,18 +109,10 @@ const ProjectType = styled.h4`
   margin: 0;
 `;
 
-const ProjectInfoContainer = styled.div`
-  ${({ isProjectHovered }) =>
-    isProjectHovered ? fadeInAnimation : fadeOutAnimation};
+const ProjectInfoContainer = styled(motion.div)`
   display: flex;
   flex-direction: column;
   justify-content: space-evenly;
-  padding-top: ${({ isProjectHovered, projectHoveredIndex }) =>
-    isProjectHovered
-      ? "0"
-      : !isProjectHovered && projectHoveredIndex === -1
-      ? "8em"
-      : "0"};
   margin: 0;
 `;
 
@@ -140,34 +159,52 @@ const ProjectTiles: React.FC<ProjectTilesProps> = ({
       return (
         <Project
           key={project.url}
-          onMouseEnter={updateProjectHoverIndex}
+          onClick={updateProjectHoverIndex}
           isProjectHovered={isProjectHovered}
           projectHoveredIndex={projectHoveredIndex}
           color={project.color}
+          initial="initial"
+          variants={projectVariants}
+          animate={
+            isProjectHovered
+              ? "expanded"
+              : projectHoveredIndex === -1
+              ? "initial"
+              : "collapsed"
+          }
         >
           <TitleTypeContainer>
             <Title>{project.title}</Title>
             <ProjectType>{project.type}</ProjectType>
           </TitleTypeContainer>
-          <ProjectInfoContainer
-            isProjectHovered={isProjectHovered}
-            projectHoveredIndex={projectHoveredIndex}
-          >
-            <TechPills>
-              {project.tech.map((singleTech) => (
-                <TechPill color={project.color} key={singleTech}>
-                  {singleTech}
-                </TechPill>
-              ))}
-            </TechPills>
-            <InfoP>
-              <BoldSpan color={project.color}>Goals:</BoldSpan> {project.goals}
-            </InfoP>
-            <InfoP>
-              <BoldSpan color={project.color}>Details:</BoldSpan>{" "}
-              {project.projectDetail}
-            </InfoP>
-          </ProjectInfoContainer>
+          <AnimatePresence initial={false}>
+            {isProjectHovered && (
+              <ProjectInfoContainer
+                isProjectHovered={isProjectHovered}
+                projectHoveredIndex={projectHoveredIndex}
+                initial="initial"
+                exit="exit"
+                animate="animate"
+                variants={infoContainerVariants}
+              >
+                <TechPills>
+                  {project.tech.map((singleTech) => (
+                    <TechPill color={project.color} key={singleTech}>
+                      {singleTech}
+                    </TechPill>
+                  ))}
+                </TechPills>
+                <InfoP>
+                  <BoldSpan color={project.color}>Goals:</BoldSpan>{" "}
+                  {project.goals}
+                </InfoP>
+                <InfoP>
+                  <BoldSpan color={project.color}>Details:</BoldSpan>{" "}
+                  {project.projectDetail}
+                </InfoP>
+              </ProjectInfoContainer>
+            )}
+          </AnimatePresence>
         </Project>
       );
     })}


### PR DESCRIPTION
### Purpose
- Prevent CSS transition from firing on load

### Validating 
Site should work as anticipated with a few caveats:
- Portfolio will now be left-most in navbar
- animations for Project and ProjectInfoContainer now use Framer Motion, and use a spring animation

### Background context
- using CSS transitions had odd effects with SSR, moved to Framer Motion instead in order to streamline animation approach on project, and ensure site loads without animations firing

### Add-on Questions
- Need to clean up the folder structure of components - ProjectTiles should be "Projects" Project should be it's own component, move Animations for Projects and ProjectInfoContainer into their own file under /Animations
- Still need to trigger animation on Circle when hitting /portfolio