### PR TITLE
Improve load time for gifs

### DIFF
--- a/components/CircleContainer/Circle.tsx
+++ b/components/CircleContainer/Circle.tsx
@@ -10,27 +10,24 @@ const StyledCircle = styled.div`
   padding-bottom: 77.75%;
   margin: 0 auto;
   border-radius: 50%;
-  border: 5px solid wheat;
+border: ${({ projectHoveredIndex, projects }) => projectHoveredIndex === -1 ? `5px solid wheat` : `5px solid ${projects[projectHoveredIndex].color}`};
+  overflow: hidden;
+  transition: border-color 0.75s ease-in-out;
   transition: ${({ pageClickedOnce }) =>
     pageClickedOnce ? "background-color 0.3s" : ""};
-  background-color: ${({ color }) => (color === "red" ? "#d13b40" : "#3bc9d1")};
-  ${({ currentPage, projects, projectHoveredIndex }) =>
-    currentPage === "PORTFOLIO" && projectHoveredIndex !== -1
-      ? `
-    background-image: url(${projects[projectHoveredIndex].gif});
-    background-size: 80%;
-    background-position: 50% 50%;
-    background-repeat: no-repeat;
-    background-color: white;
-    border: 5px solid ${projects[projectHoveredIndex].color};
-    transition: border-color 0.75s ease-in-out;
-    transition: background-image 0.25s ease-in-out;
-  `
-      : null}
+  background-color: ${({ color }) => (color === "red" ? "#d13b40" : color === "blue" ? "#3bc9d1" : "#fff")};
   @media screen and (min-width: 768px) {
     width: 100%;
     padding-bottom: 97.75%;
   }
+`;
+
+const StyledGif = styled.img`
+  position: absolute;
+  height: 75%;
+  width: 75%;
+  left: 12.5%;
+  top: 12.5%;
 `;
 
 interface CircleProps {
@@ -48,12 +45,20 @@ const Circle: React.FC<CircleProps> = ({
 }) => (
   <CircleAnimation currentPage={currentPage} pageClickedOnce={pageClickedOnce}>
     <StyledCircle
-      color={currentPage === "SKILLS" ? "red" : "blue"}
+      color={currentPage === "SKILLS" ? "red" : currentPage === "ABOUT" ? "blue" : "white"}
       pageClickedOnce={pageClickedOnce}
       currentPage={currentPage}
       projects={projects}
       projectHoveredIndex={projectHoveredIndex}
-    />
+    >
+      {projectHoveredIndex === 0 ? (
+        <StyledGif src={require("../../public/images/whidbeyherbal.gif")} />
+      ) : projectHoveredIndex === 1 ? (
+        <StyledGif src={require("../../public/images/chatapp.gif")} />
+      ) : projectHoveredIndex === 2 ? (
+        <StyledGif src={require("../../public/images/taskmanager.gif")} />
+      ) : null}
+    </StyledCircle>
   </CircleAnimation>
 );
 

--- a/components/CircleContainer/index.tsx
+++ b/components/CircleContainer/index.tsx
@@ -23,13 +23,13 @@ const CircleContainer: React.FC<CircleContainerProps> = ({
   pageClickedOnce,
   children,
   projects,
-  projectHoveredIndex
+  projectHoveredIndex,
 }) => (
   <CircleContainerDiv>
     {children}
-    <Circle 
-      currentPage={currentPage} 
-      pageClickedOnce={pageClickedOnce} 
+    <Circle
+      currentPage={currentPage}
+      pageClickedOnce={pageClickedOnce}
       projects={projects}
       projectHoveredIndex={projectHoveredIndex}
     />

--- a/components/ImageComponents/ComputerImage.tsx
+++ b/components/ImageComponents/ComputerImage.tsx
@@ -23,7 +23,6 @@ const StyledComputerImage = styled.img`
   animation-delay: 200ms;
   transition: ${({ pageClickedOnce, projectHoveredIndex }) =>
     pageClickedOnce || projectHoveredIndex !== -1 ? "filter 2s" : ""};
-  transition: left 5s ease-in-out;
   filter: ${({ currentPage, projectHoveredIndex }) =>
     triggerFilter(currentPage, projectHoveredIndex)};
 `;


### PR DESCRIPTION
### Purpose
- Gifs were delaying a bit before showing on screen and wanted that to feel more immediate
- I believe that Next.js doesn't do the same image pre-loading for css backgrounds as it does as images, so hopefully converting the Gifs into images will resolve the issue

### Validating
- Everything should work as normal, but note that I made the circle color white on init load