### PR TITLE
Style skills and about pages

### DIFF
--- a/components/AboutSection.tsx
+++ b/components/AboutSection.tsx
@@ -1,0 +1,50 @@
+import styled from "styled-components";
+import Pill from "./SharedComponents/Pill";
+import { devices } from "../utils/cssBreakpoints";
+
+const AboutContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  height: 100%;
+`;
+
+const Headline = styled.h2`
+  font-size: 1.75em;
+  font-weight: 600;
+  @media ${devices.mobileLandscape} {
+    margin: 0.125em 0;
+    font-size: 2.25em;
+  }
+`;
+
+const Info = styled.p`
+  font-size: 0.825em;
+  @media ${devices.mobileLandscape} {
+    margin: 0.75em 0;
+    font-size: 0.85em;
+  }
+`;
+
+const SkillsSection: React.FC = () => (
+  <AboutContainer>
+    <Headline>
+      My background is in life coaching, solutions engineering, vendor
+      management, and sales.
+    </Headline>
+    <Info>
+      When I’m not working, I’m hanging out with my wife and daughter, playing
+      pinball, or rollerskating.
+    </Info>
+    <Info>
+      You can also find me volunteering for the{" "}
+      <a href="https://github.com/codeforpdx/dwellingly-app" target="_blank">
+        Dwelling.ly
+      </a>{" "}
+      project at Code for PDX and participating in coding meetups like Portland
+      ReactJS and Mentorship Saturdays.
+    </Info>
+  </AboutContainer>
+);
+
+export default SkillsSection;

--- a/components/InfoText.tsx
+++ b/components/InfoText.tsx
@@ -9,9 +9,7 @@ const InfoTextContainer = styled.div`
   height: 57%;
   margin: 0 auto;
   font-family: "Muli", sans-serif;
-  font-size: ${({ onProjectsPage }) => onProjectsPage ? "0.825rem" : "0.85rem"};
   font-weight: 400;
-  line-height: 1.5em;
   color: #333333;
   @media ${devices.mobileLandscape} {
     height: 53%;
@@ -33,7 +31,7 @@ const InfoText: React.FC<InfoTextProps> = ({
   updateProjectHoveredIndex,
   projectHoveredIndex,
 }) =>
-  currentPage !== "portfolio" ? (
+  currentPage === "skills" ? (
     <InfoTextContainer
       currentPage={currentPage}
       dangerouslySetInnerHTML={infoText}

--- a/components/InfoText.tsx
+++ b/components/InfoText.tsx
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 import Projects from "./Projects";
 import SkillsSection from "./SkillsSection";
+import AboutSection from "./AboutSection";
 import { ProjectModel } from "../models/appState";
 import { devices } from "../utils/cssBreakpoints";
 
@@ -40,7 +41,7 @@ const InfoText: React.FC<InfoTextProps> = ({
   ) : currentPage === "about" ? (
     <InfoTextContainer
     >
-     about 
+     <AboutSection />
     </InfoTextContainer>
   ) : (
     <InfoTextContainer onProjectsPage={true}>

--- a/components/InfoText.tsx
+++ b/components/InfoText.tsx
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import Projects from "./Projects";
+import SkillsSection from "./SkillsSection";
 import { ProjectModel } from "../models/appState";
 import { devices } from "../utils/cssBreakpoints";
 
@@ -33,10 +34,14 @@ const InfoText: React.FC<InfoTextProps> = ({
 }) =>
   currentPage === "skills" ? (
     <InfoTextContainer
-      currentPage={currentPage}
-      dangerouslySetInnerHTML={infoText}
-      onProjectsPage={false}
-    ></InfoTextContainer>
+    >
+      <SkillsSection />
+    </InfoTextContainer>
+  ) : currentPage === "about" ? (
+    <InfoTextContainer
+    >
+     about 
+    </InfoTextContainer>
   ) : (
     <InfoTextContainer onProjectsPage={true}>
       <Projects

--- a/components/Projects/Project.tsx
+++ b/components/Projects/Project.tsx
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronDown, faChevronUp } from "@fortawesome/free-solid-svg-icons";
 import { ProjectModel } from "../../models/appState";
 import ProjectInfo from "./ProjectInfo";
+import Pill from "../SharedComponents/Pill";
 import { devices } from "../../utils/cssBreakpoints";
 
 const projectVariants = {
@@ -74,16 +75,6 @@ const TechPills = styled.div`
   margin: 0;
 `;
 
-const TechPill = styled.div`
-  height: 1.75em;
-  padding: 0.133em 0.825em;
-  margin: 0 0.75em 0 0;
-  color: #584D4D;
-  background-color: #f2f2f2;
-  border-radius: 1000px;
-  font-size: 0.825em;
-`;
-
 interface ProjectProps {
   project: ProjectModel;
   handleProjectHover: (projectIndex) => void;
@@ -127,13 +118,7 @@ const Project: React.FC<ProjectProps> = ({
         </ProjectHeader>
         <TechPills>
           {project.tech.map((singleTech) => (
-            <TechPill
-              color={project.color}
-              key={singleTech}
-              isProjectHovered={isProjectHovered}
-            >
-              {singleTech}
-            </TechPill>
+            <Pill setMargin={"0 0.75em 0 0"}>{singleTech}</Pill>
           ))}
         </TechPills>
       </ProjectOverview>

--- a/components/Projects/Project.tsx
+++ b/components/Projects/Project.tsx
@@ -75,7 +75,7 @@ const TechPills = styled.div`
 `;
 
 const TechPill = styled.div`
-  height: 2em;
+  height: 1.75em;
   padding: 0.133em 0.825em;
   margin: 0 0.75em 0 0;
   color: #584D4D;

--- a/components/Projects/Project.tsx
+++ b/components/Projects/Project.tsx
@@ -117,8 +117,8 @@ const Project: React.FC<ProjectProps> = ({
           )}
         </ProjectHeader>
         <TechPills>
-          {project.tech.map((singleTech) => (
-            <Pill setMargin={"0 0.75em 0 0"}>{singleTech}</Pill>
+          {project.tech.map((techName) => (
+            <Pill key={techName} setMargin={"0 0.75em 0 0"}>{techName}</Pill>
           ))}
         </TechPills>
       </ProjectOverview>

--- a/components/SharedComponents/Pill.tsx
+++ b/components/SharedComponents/Pill.tsx
@@ -1,0 +1,25 @@
+import styled from "styled-components";
+import { ReactElement } from "react";
+
+const PillContainer = styled.div`
+  height: 1.75em;
+  padding: 0.133em 0.825em;
+  margin: ${({ setMargin }) => setMargin ? setMargin : "0 0 0 0" };
+  color: #584d4d;
+  background-color: #f2f2f2;
+  border-radius: 1000px;
+  font-size: 0.825em;
+`;
+
+interface PillProps {
+  children: string;
+  setMargin: string;
+}
+
+const Pill: React.FC<PillProps> = ({ children, setMargin }) => (
+  <PillContainer setMargin={setMargin}>
+    {children}
+  </PillContainer>
+);
+
+export default Pill;

--- a/components/SkillsSection.tsx
+++ b/components/SkillsSection.tsx
@@ -1,0 +1,74 @@
+import styled from "styled-components";
+import Pill from "./SharedComponents/Pill";
+import { devices } from "../utils/cssBreakpoints";
+
+const Headline = styled.h2`
+  font-size: 1.75em;
+  font-weight: 600;
+  @media ${devices.mobileLandscape} {
+    font-size: 2.25em;
+  }
+`;
+
+const Info = styled.p`
+  font-size: 0.825em;
+  @media ${devices.mobileLandscape} {
+    font-size: 2.25em;
+  }
+`;
+
+const TechContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 0.825em;
+`;
+
+const Styledh3 = styled.h3`
+  margin: 0.5em 0;
+  padding: 0;
+  font-size: 0.825em;
+`;
+
+const languagesAndTools = [
+  "JavaScript ES6",
+  "TypeScript",
+  "NodeJS",
+  "Python",
+  "React",
+  "Redux",
+  "Gatsby.js",
+  "Next.js",
+  "Styled-Components",
+  "Webpack",
+  "Express",
+  "RESTful API's",
+  "MongoDB",
+  "Mongoose",
+  "Socket.io",
+  "Jest",
+  "Github",
+  "TDD",
+  "Figma",
+  "Adobe Creative Suite",
+  "Shopify",
+];
+
+const SkillsSection: React.FC = () => (
+  <>
+    <Headline>I use code to bring people together and have fun.</Headline>
+    <Info>
+      I am a detail oriented and intrinsically motivated software engineer with
+      5 years’ experience creating custom websites using HTML/CSS/JavaScript,
+      and eight years’ experience working directly with clients to solve complex
+      technical challenges.
+    </Info>
+    <Styledh3>Languages and Tools:</Styledh3>
+    <TechContainer>
+      {languagesAndTools.map((techName) => (
+        <Pill key={techName} setMargin={"0.25em"}>{techName}</Pill>
+      ))}
+    </TechContainer>
+  </>
+);
+
+export default SkillsSection;

--- a/components/SkillsSection.tsx
+++ b/components/SkillsSection.tsx
@@ -2,9 +2,18 @@ import styled from "styled-components";
 import Pill from "./SharedComponents/Pill";
 import { devices } from "../utils/cssBreakpoints";
 
+const SkillsContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  height: 100%;
+`;
+
 const Headline = styled.h2`
   font-size: 1.75em;
   font-weight: 600;
+  margin: 0;
+  padding: 0;
   @media ${devices.mobileLandscape} {
     font-size: 2.25em;
   }
@@ -12,8 +21,10 @@ const Headline = styled.h2`
 
 const Info = styled.p`
   font-size: 0.825em;
+  margin: 0;
+  padding: 0;
   @media ${devices.mobileLandscape} {
-    font-size: 2.25em;
+    font-size: 0.85em;
   }
 `;
 
@@ -54,21 +65,25 @@ const languagesAndTools = [
 ];
 
 const SkillsSection: React.FC = () => (
-  <>
+  <SkillsContainer>
     <Headline>I use code to bring people together and have fun.</Headline>
     <Info>
       I am a detail oriented and intrinsically motivated software engineer with
-      5 years’ experience creating custom websites using HTML/CSS/JavaScript,
+      five years’ experience creating custom websites using HTML/CSS/JavaScript,
       and eight years’ experience working directly with clients to solve complex
       technical challenges.
     </Info>
-    <Styledh3>Languages and Tools:</Styledh3>
-    <TechContainer>
-      {languagesAndTools.map((techName) => (
-        <Pill key={techName} setMargin={"0.25em"}>{techName}</Pill>
-      ))}
-    </TechContainer>
-  </>
+    <div>
+      <Styledh3>Languages and Tools:</Styledh3>
+      <TechContainer>
+        {languagesAndTools.map((techName) => (
+          <Pill key={techName} setMargin={"0.25em"}>
+            {techName}
+          </Pill>
+        ))}
+      </TechContainer>
+    </div>
+  </SkillsContainer>
 );
 
 export default SkillsSection;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -29,7 +29,7 @@ const MainContent = styled.div`
 export default function Home() {
   // infoText's structure allows the html to be injected via dangerouslySetInnerHTML
   const [appState, updateAppState] = useState<AppStateModel>({
-    currentPage: "skills",
+    currentPage: "about",
     projectHoveredIndex: -1,
     indexToSelect: 0,
     pages: [

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -29,7 +29,7 @@ const MainContent = styled.div`
 export default function Home() {
   // infoText's structure allows the html to be injected via dangerouslySetInnerHTML
   const [appState, updateAppState] = useState<AppStateModel>({
-    currentPage: "portfolio",
+    currentPage: "skills",
     projectHoveredIndex: -1,
     indexToSelect: 0,
     pages: [


### PR DESCRIPTION
### Purpose
- Fit the new design from Kayla

### Validating
- No text should overflow on About and Skills pages
- Tech Pills on Portfolio should not be changed (i refactored the way Pills are used to make them more extensible so that "skills" and "portfolio" could use the same reusable Pill component

### Questions
- Not a question, but more of a fact - need to look into making it responsive for large screens
- Also not a question, but worth pointing out that I considered removing the images on the left and right at smaller resolutions when they began to get cropped by the viewport, but decided not to because I liked the organic and imperfect nature they have - the rest of the design is so clean and crisp, i like these being little chaotic elements that don't always fit somewhere exactly