### PR TITLE
Fade App in on load

### DIFF
--- a/animations/FadeInAnimation.tsx
+++ b/animations/FadeInAnimation.tsx
@@ -1,0 +1,49 @@
+import { motion } from "framer-motion";
+import { css } from "styled-jsx/css";
+import { ReactElement } from "react";
+
+interface FadeInAnimationProps {
+  children: ReactElement;
+}
+
+// enable styling for motion.div
+const { className, styles } = css.resolve`
+  div {
+    position: relative;
+    display: block;
+    height: 100%;
+    width: 100%;
+    margin: 0 auto;
+  }
+`;
+
+const fadeInVariants = {
+  initial: {
+    opacity: 0,
+  },
+  exit: {
+    opacity: 0,
+  },
+  animate: {
+    opacity: 1,
+  },
+};
+
+const FadeInAnimation: React.FC<FadeInAnimationProps> = ({
+  children,
+}) => (
+  /* animate ternary ensures that circle doesn't animate on init load */
+  <motion.div
+    className={className}
+    initial="initial"
+    animate="animate"
+    exit="exit"
+    variants={fadeInVariants}
+    transition={{ ease: "easeInOut", timing: [0, 1] }}
+  >
+    {children}
+    {styles}
+  </motion.div>
+);
+
+export default FadeInAnimation;

--- a/components/CircleContainer/Circle.tsx
+++ b/components/CircleContainer/Circle.tsx
@@ -54,18 +54,6 @@ const Circle: React.FC<CircleProps> = ({
       projects={projects}
       projectHoveredIndex={projectHoveredIndex}
     >
-      <StyledGif
-        isSelected={projectHoveredIndex === 0}
-        src="/images/whidbeyherbal.gif"
-      />
-      <StyledGif
-        isSelected={projectHoveredIndex === 1}
-        src="/images/chatapp.gif"
-      />
-      <StyledGif
-        isSelected={projectHoveredIndex === 2}
-        src="/images/taskmanager.gif"
-      />
     </StyledCircle>
   </CircleAnimation>
 );

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,7 @@
 import React from "react";
 import App, { Container } from "next/app";
+import { AnimatePresence } from "framer-motion";
+import FadeInAnimation from '../animations/FadeInAnimation';
 
 import { config } from "@fortawesome/fontawesome-svg-core";
 import "@fortawesome/fontawesome-svg-core/styles.css"; // Import the CSS
@@ -8,7 +10,13 @@ config.autoAddCss = false; // Tell Font Awesome to skip adding the CSS automatic
 class MyApp extends App {
   render() {
     const { Component, pageProps } = this.props;
-    return <Component {...pageProps} />;
+    return (
+      <AnimatePresence>
+        <FadeInAnimation>
+          <Component {...pageProps} />;
+        </FadeInAnimation>
+      </AnimatePresence>
+    );
   }
 }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -29,7 +29,7 @@ const MainContent = styled.div`
 export default function Home() {
   // infoText's structure allows the html to be injected via dangerouslySetInnerHTML
   const [appState, updateAppState] = useState<AppStateModel>({
-    currentPage: "about",
+    currentPage: "skills",
     projectHoveredIndex: -1,
     indexToSelect: 0,
     pages: [


### PR DESCRIPTION
### Purpose
- Fade app in once content is loaded

### Validating
- App should fade in on load
- The only item that will update after fade-in (on slow connections) is the font, which needs to be investigated further

### Questions
- I removed the StyledGif JSX in Circle.tsx, because that implementation wasn't working correctly.
- If i use an animated image I will use webm and fallback to gif if needed. That said, using a Gif will require changing the usage of the circle
- Will likely want to wrap StyledGif in animatepresence to fade in the animation and keep load times quick.