### PR TITLE
Expand circle into pill shape on project click

### DIFF
--- a/animations/ImageAnimation.tsx
+++ b/animations/ImageAnimation.tsx
@@ -23,8 +23,8 @@ const { className, styles } = css.resolve`
 
 const imageVariants = {
   center: (leftOriented) => ({
-    x: leftOriented ? "-40%" : "60%",
-    y: "-7.5vh",
+    x: leftOriented ? "22.5%" : "52.5%",
+    y: "-15vh",
     transition: {
       type: "spring",
       stiffness: 35,
@@ -33,24 +33,24 @@ const imageVariants = {
     },
   }),
   flyOut: (leftOriented) => ({
-    x: leftOriented ? "-200%" : "215%",
-    y: "-7.5vh",
+    x: leftOriented ? "-37.5%" : "110%",
+    y: "-15vh",
     transition: {
       type: "spring",
       stiffness: 35,
     },
   }),
   portfolioUp: (leftOriented) => ({
-    x: leftOriented ? "-200%" : "215%",
-    y: "40vh",
+    x: leftOriented ? "-37.5%" : "110%",
+    y: "30vh",
     transition: {
       type: "spring",
       stiffness: 35,
     },
   }),
   portfolioDown: (leftOriented) => ({
-    x: leftOriented ? "-200%" : "200%",
-    y: "-15vh",
+    x: leftOriented ? "-37.5%" : "110%",
+    y: "-25vh",
     transition: {
       type: "spring",
       stiffness: 35,

--- a/components/CircleContainer/Circle.tsx
+++ b/components/CircleContainer/Circle.tsx
@@ -6,10 +6,9 @@ const StyledCircle = styled.div`
   position: relative;
   display: block;
   width: 100%;
-  /* padding-bottom keeps circle proportional */
-  padding-bottom: 100%;
+  height: 100%;
   margin: 0 auto;
-  border-radius: 50%;
+border-radius: ${({ projectHoveredIndex }) => projectHoveredIndex !== -1 ? "10000px" : "50%"};
   overflow: hidden;
   transition: ${({ pageClickedOnce }) =>
     pageClickedOnce ? "background-color 0.75s" : ""};
@@ -54,6 +53,18 @@ const Circle: React.FC<CircleProps> = ({
       projects={projects}
       projectHoveredIndex={projectHoveredIndex}
     >
+      {/* <StyledGif
+        isSelected={projectHoveredIndex === 0}
+        src="/images/whidbeyherbal.gif"
+      />
+      <StyledGif
+        isSelected={projectHoveredIndex === 1}
+        src="/images/chatapp.gif"
+      />
+      <StyledGif
+        isSelected={projectHoveredIndex === 2}
+        src="/images/taskmanager.gif"
+      /> */}
     </StyledCircle>
   </CircleAnimation>
 );

--- a/components/CircleContainer/Circle.tsx
+++ b/components/CircleContainer/Circle.tsx
@@ -8,7 +8,7 @@ const StyledCircle = styled.div`
   width: 100%;
   height: 100%;
   margin: 0 auto;
-border-radius: ${({ projectHoveredIndex }) => projectHoveredIndex !== -1 ? "10000px" : "50%"};
+  border-radius: 10000px;
   overflow: hidden;
   transition: ${({ pageClickedOnce }) =>
     pageClickedOnce ? "background-color 0.75s" : ""};

--- a/components/CircleContainer/index.tsx
+++ b/components/CircleContainer/index.tsx
@@ -8,7 +8,7 @@ const CircleContainerDiv = styled.div`
   width: ${({ projectHoveredIndex }) =>
     projectHoveredIndex !== -1 ? "100%" : "28vh"};
   margin: 0 auto;
-  transition: width 2s;
+  transition: width 0.75s;
 `;
 
 interface CircleContainerProps {

--- a/components/CircleContainer/index.tsx
+++ b/components/CircleContainer/index.tsx
@@ -5,8 +5,11 @@ import { ProjectModel } from "../../models/appState";
 
 const CircleContainerDiv = styled.div`
   position: relative;
-  width: 40.625%;
+  height: 28vh;
+  width: ${({ projectHoveredIndex }) =>
+    projectHoveredIndex !== -1 ? "100%" : "28vh"};
   margin: 0 auto;
+  transition: width 2s;
 `;
 
 interface CircleContainerProps {
@@ -24,7 +27,7 @@ const CircleContainer: React.FC<CircleContainerProps> = ({
   projects,
   projectHoveredIndex,
 }) => (
-  <CircleContainerDiv>
+  <CircleContainerDiv projectHoveredIndex={projectHoveredIndex}>
     {children}
     <Circle
       currentPage={currentPage}

--- a/components/CircleContainer/index.tsx
+++ b/components/CircleContainer/index.tsx
@@ -1,6 +1,5 @@
 import styled from "styled-components";
 import Circle from "./Circle";
-import { ReactElement } from "react";
 import { ProjectModel } from "../../models/appState";
 
 const CircleContainerDiv = styled.div`
@@ -15,7 +14,6 @@ const CircleContainerDiv = styled.div`
 interface CircleContainerProps {
   currentPage: string;
   pageClickedOnce: boolean;
-  children: ReactElement[];
   projectHoveredIndex: number;
   projects: ProjectModel[];
 }
@@ -23,12 +21,10 @@ interface CircleContainerProps {
 const CircleContainer: React.FC<CircleContainerProps> = ({
   currentPage,
   pageClickedOnce,
-  children,
   projects,
   projectHoveredIndex,
 }) => (
   <CircleContainerDiv projectHoveredIndex={projectHoveredIndex}>
-    {children}
     <Circle
       currentPage={currentPage}
       pageClickedOnce={pageClickedOnce}

--- a/components/ImageComponents/ComputerImage.tsx
+++ b/components/ImageComponents/ComputerImage.tsx
@@ -1,5 +1,5 @@
 import styled, { keyframes } from "styled-components";
-import triggerFilter from "../../animations/TriggerFilter";
+import { devices } from "../../utils/cssBreakpoints";
 import ImageModel from "../../models/images";
 
 const rotate = keyframes`
@@ -17,11 +17,15 @@ const rotate = keyframes`
 const StyledComputerImage = styled.img`
   display: block;
   position: absolute;
-  margin: 30vh 0 0 -5%;
-  width: 32.5%;
+  width: 50%;
+  margin: 25vh 0 0 -20%;
   animation: ${rotate} 90s infinite linear;
   animation-delay: 200ms;
   opacity: 0.15;
+  @media ${devices.mobileLandscape} {
+    width: 32.5%;
+    margin: 30vh 0 0 -5%;
+  }
 `;
 
 const ComputerImage: React.FC<ImageModel> = ({

--- a/components/ImageComponents/ComputerImage.tsx
+++ b/components/ImageComponents/ComputerImage.tsx
@@ -17,8 +17,8 @@ const rotate = keyframes`
 const StyledComputerImage = styled.img`
   display: block;
   position: absolute;
-  margin: 25% 0 0 0;
-  width: 110%;
+  margin: 30vh 0 0 -5%;
+  width: 32.5%;
   animation: ${rotate} 90s infinite linear;
   animation-delay: 200ms;
   opacity: 0.15;

--- a/components/ImageComponents/PhoneImage.tsx
+++ b/components/ImageComponents/PhoneImage.tsx
@@ -1,6 +1,6 @@
 import styled, { keyframes } from 'styled-components';
 import ImageModel from "../../models/images";
-import triggerFilter from "../../animations/TriggerFilter";
+import { devices } from "../../utils/cssBreakpoints";
 
 const rotate = keyframes`
   0% {
@@ -17,12 +17,16 @@ const rotate = keyframes`
 const StyledPhoneImage = styled.img`
   display: block;
   position: absolute;
-  margin: 32.5vh 0 0 5%;
-  width: 20%;
+  margin: 25vh 0 0 0%;
+  width: 32.5%;
   height: auto;
   animation: ${rotate} 90s infinite linear;
   animation-delay: 300ms;
   opacity: 0.15;
+  @media ${devices.mobileLandscape} {
+    width: 20%;
+    margin: 32.5vh 0 0 5%;
+  }
 `;
 
 const PhoneImage: React.FC<ImageModel> = ({ currentPage, pageClickedOnce, projectHoveredIndex }) => (

--- a/components/ImageComponents/PhoneImage.tsx
+++ b/components/ImageComponents/PhoneImage.tsx
@@ -17,8 +17,8 @@ const rotate = keyframes`
 const StyledPhoneImage = styled.img`
   display: block;
   position: absolute;
-  margin: 25% 0 0 0;
-  width: 70%;
+  margin: 32.5vh 0 0 5%;
+  width: 20%;
   height: auto;
   animation: ${rotate} 90s infinite linear;
   animation-delay: 300ms;

--- a/components/ImageComponents/PinballImage.tsx
+++ b/components/ImageComponents/PinballImage.tsx
@@ -17,8 +17,8 @@ const rotate = keyframes`
 const StyledPinballImage = styled.img`
   display: block;
   position: absolute;
-  margin: 25% 0 0 0;
-  width: 80%;
+  margin: 30vh 0 0 0;
+  width: 22.5%;
   animation: ${rotate} 80s infinite linear;
   animation-delay: 100ms;
   opacity: 0.15;

--- a/components/ImageComponents/PinballImage.tsx
+++ b/components/ImageComponents/PinballImage.tsx
@@ -1,5 +1,5 @@
 import styled, { keyframes } from 'styled-components';
-import triggerFilter from "../../animations/TriggerFilter";
+import { devices } from "../../utils/cssBreakpoints";
 import ImageModel from "../../models/images";
 
 const rotate = keyframes`
@@ -17,11 +17,15 @@ const rotate = keyframes`
 const StyledPinballImage = styled.img`
   display: block;
   position: absolute;
-  margin: 30vh 0 0 0;
-  width: 22.5%;
+  margin: 28vh 0 0 -7.5%;
+  width: 32.5%;
   animation: ${rotate} 80s infinite linear;
   animation-delay: 100ms;
   opacity: 0.15;
+  @media ${devices.mobileLandscape} {
+    width: 22.5%;
+    margin: 30vh 0 0 0;
+  }
 `;
 
 const PinballImage: React.FC<ImageModel> = ({

--- a/components/ImageComponents/RollerskateImage.tsx
+++ b/components/ImageComponents/RollerskateImage.tsx
@@ -17,8 +17,8 @@ const rotate = keyframes`
 const StyledRollerskateImage = styled.img`
   display: block;
   position: absolute;
-  margin: 25% 0 0 0;
-  width: 90%;
+  margin: 32.5vh 0 0 0;
+  width: 25%;
   animation: ${rotate} 80s infinite linear;
   animation-delay: 400ms;
   opacity: 0.15;

--- a/components/ImageComponents/RollerskateImage.tsx
+++ b/components/ImageComponents/RollerskateImage.tsx
@@ -1,5 +1,5 @@
 import styled, { keyframes } from 'styled-components';
-import triggerFilter from '../../animations/TriggerFilter';
+import { devices } from "../../utils/cssBreakpoints";
 import ImageModel from '../../models/images';
 
 const rotate = keyframes`
@@ -17,11 +17,15 @@ const rotate = keyframes`
 const StyledRollerskateImage = styled.img`
   display: block;
   position: absolute;
-  margin: 32.5vh 0 0 0;
-  width: 25%;
+  margin: 30vh 0 0 0;
+  width: 35%;
   animation: ${rotate} 80s infinite linear;
   animation-delay: 400ms;
   opacity: 0.15;
+  @media ${devices.mobileLandscape} {
+    width: 25%;
+    margin: 32.5vh 0 0 0;
+  }
 `;
 
 const RollerskateImage: React.FC<ImageModel> = ({

--- a/components/InfoText.tsx
+++ b/components/InfoText.tsx
@@ -44,7 +44,7 @@ const InfoText: React.FC<InfoTextProps> = ({
      <AboutSection />
     </InfoTextContainer>
   ) : (
-    <InfoTextContainer onProjectsPage={true}>
+    <InfoTextContainer>
       <Projects
         projects={projects}
         updateProjectHoveredIndex={updateProjectHoveredIndex}

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -13,7 +13,7 @@ const StyledLayout = styled.div`
 `;
 
 interface LayoutProps {
-  children: ReactElement;
+  children: ReactElement[];
 }
 
 const Layout: React.FC<LayoutProps> = ({ children }) => (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -29,7 +29,7 @@ const MainContent = styled.div`
 export default function Home() {
   // infoText's structure allows the html to be injected via dangerouslySetInnerHTML
   const [appState, updateAppState] = useState<AppStateModel>({
-    currentPage: "about",
+    currentPage: "portfolio",
     projectHoveredIndex: -1,
     indexToSelect: 0,
     pages: [

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -29,7 +29,7 @@ const MainContent = styled.div`
 export default function Home() {
   // infoText's structure allows the html to be injected via dangerouslySetInnerHTML
   const [appState, updateAppState] = useState<AppStateModel>({
-    currentPage: "skills",
+    currentPage: "about",
     projectHoveredIndex: -1,
     indexToSelect: 0,
     pages: [
@@ -151,6 +151,18 @@ export default function Home() {
         <link rel="manifest" href="/site.webmanifest" />
       </Head>
       <Layout>
+        <ImagePairs
+          leftOriented={true}
+          currentPage={appState.currentPage}
+          pageClickedOnce={appState.pageClickedOnce}
+          projectHoveredIndex={appState.projectHoveredIndex}
+        />
+        <ImagePairs
+          leftOriented={false}
+          currentPage={appState.currentPage}
+          pageClickedOnce={appState.pageClickedOnce}
+          projectHoveredIndex={appState.projectHoveredIndex}
+        />
         <MainContent>
           <TitleText />
           <CircleContainer
@@ -158,20 +170,7 @@ export default function Home() {
             pageClickedOnce={appState.pageClickedOnce}
             projectHoveredIndex={appState.projectHoveredIndex}
             projects={appState.projects}
-          >
-            <ImagePairs
-              leftOriented={true}
-              currentPage={appState.currentPage}
-              pageClickedOnce={appState.pageClickedOnce}
-              projectHoveredIndex={appState.projectHoveredIndex}
-            />
-            <ImagePairs
-              leftOriented={false}
-              currentPage={appState.currentPage}
-              pageClickedOnce={appState.pageClickedOnce}
-              projectHoveredIndex={appState.projectHoveredIndex}
-            />
-          </CircleContainer>
+          ></CircleContainer>
           <InfoText
             infoText={appState.infoText[appState.currentPage]}
             currentPage={appState.currentPage}


### PR DESCRIPTION
### Purpose
- When a project is clicked, expand circle into a pill 100% width of MainContent
- When navigated to another page, revert back to circle

### Validating
- Circle should expand to 100% of MainContent's width when project is clicked
- Images may appear different in size/position slightly, because they had to be moved to a child of Layout instead of CircleContainer, and thus their margins and size were adjusted to match Layout
- LargeScreen may look odd, a ticket  needs to be created to optimize the site for large screens

### Background
- Expanding the circle into a pill paves the way for showing project images/gifs when projects are selected
- Since the circle by itself was too small to properly see a preview of the project, the pill shape allows the user to see more of the project
- Note that refactoring this required moving the Images out of CircleContainer and make them a child of Layout