### PR TITLE
fix gif playback, adjust vertical spacing on mobile

### DIFF
--- a/components/CircleContainer/Circle.tsx
+++ b/components/CircleContainer/Circle.tsx
@@ -12,7 +12,7 @@ const StyledCircle = styled.div`
   margin: 0 auto;
   border-radius: 10000px;
   overflow: hidden;
-  transition: background-color 0.75s;
+  transition: background-color 0.5s;
   background-color: ${({ color }) =>
     color === "grey" ? "#4A505F" : color === "yellow" ? "#F9E44D" : color === "reddish" ? "#883B38" : "white"};
 `;
@@ -24,7 +24,6 @@ const StyledVideo = styled(motion.video)`
   margin: 0 auto;
   @media ${devices.mobileLandscape} {
     position: absolute;
-    width: 100%;
     height: auto;
     bottom: 0;
   }
@@ -67,6 +66,7 @@ const Circle: React.FC<CircleProps> = ({
             autoPlay
             loop
             muted
+            playsinline
             controls={false}
             key={openProject.title}
             animate={{ opacity: 1 }}

--- a/components/InfoText.tsx
+++ b/components/InfoText.tsx
@@ -8,7 +8,7 @@ import { devices } from "../utils/cssBreakpoints";
 const InfoTextContainer = styled.div`
   position: relative;
   width: 100%;
-  height: 57%;
+  height: 52%;
   margin: 0 auto;
   font-family: "Muli", sans-serif;
   font-weight: 400;

--- a/components/PageLinkContainer/index.tsx
+++ b/components/PageLinkContainer/index.tsx
@@ -7,8 +7,8 @@ const LinkContainer = styled.div`
   display: flex;
   justify-content: space-evenly;
   align-items: center;
-  margin: 0 auto;
   width: 100%;
+  margin: 0 auto 2.5% auto;
   z-index: 99;
   @media ${devices.tabletLandscape} {
     position: fixed;


### PR DESCRIPTION
### Purpose
- On mobile, when clicking a project the gif would play full screen and not get masked by the pill shape, needed to have it behave the same way as on browser
- Fix issue where InfoText overflowed the nav, and the nav sat too low on the window

### Validating
- On mobile, clicking a project should run gif just as it does on desktop
- InfoText should not overflow nav
- Nav should have some bottom margin to keep it far enough away from the mobile browser's bottom toolbar