### PR TITLE
Mobile gif hotfix

### DIFF
--- a/components/CircleContainer/Circle.tsx
+++ b/components/CircleContainer/Circle.tsx
@@ -66,7 +66,7 @@ const Circle: React.FC<CircleProps> = ({
             autoPlay
             loop
             muted
-            playsinline
+            playsInLine
             controls={false}
             key={openProject.title}
             animate={{ opacity: 1 }}

--- a/components/PageLinkContainer/index.tsx
+++ b/components/PageLinkContainer/index.tsx
@@ -8,7 +8,7 @@ const LinkContainer = styled.div`
   justify-content: space-evenly;
   align-items: center;
   width: 100%;
-  margin: 0 auto 2.5% auto;
+  margin: 1% auto;
   z-index: 99;
   @media ${devices.tabletLandscape} {
     position: fixed;


### PR DESCRIPTION
Trying to prevent gif from entering video mode and popping out of the layout when a project is clicked.

Also adjusted margin on PageLinkContainer to get it to sit better on mobile.