### PR TITLE
Style for large screen

### DIFF
--- a/components/AboutSection.tsx
+++ b/components/AboutSection.tsx
@@ -1,5 +1,4 @@
 import styled from "styled-components";
-import Pill from "./SharedComponents/Pill";
 import { devices } from "../utils/cssBreakpoints";
 
 const AboutContainer = styled.div`
@@ -17,6 +16,9 @@ const Headline = styled.h2`
     margin: 0.125em 0;
     font-size: 2.25em;
   }
+  @media ${devices.largeScreen} {
+    margin: 0.5em 0;
+  }
 `;
 
 const Info = styled.p`
@@ -25,6 +27,10 @@ const Info = styled.p`
   @media ${devices.mobileLandscape} {
     margin: 0.75em 0;
     font-size: 0.85em;
+  }
+  @media ${devices.largeScreen} {
+    font-size: 1em;
+    margin: 1em 0;
   }
 `;
 

--- a/components/AboutSection.tsx
+++ b/components/AboutSection.tsx
@@ -6,19 +6,18 @@ const AboutContainer = styled.div`
   flex-direction: column;
   justify-content: flex-start;
   height: 100%;
+  @media ${devices.mobileLandscape} {
+    font-size: 1.125em;
+  }
+  @media ${devices.largeScreen} {
+    font-size: 1.25em;
+  }
 `;
 
 const Headline = styled.h2`
   font-size: 1.75em;
   font-weight: 600;
   margin: 0.5em 0;
-  @media ${devices.mobileLandscape} {
-    margin: 0.125em 0;
-    font-size: 2.25em;
-  }
-  @media ${devices.largeScreen} {
-    margin: 0.5em 0;
-  }
 `;
 
 const Info = styled.p`
@@ -27,10 +26,6 @@ const Info = styled.p`
   @media ${devices.mobileLandscape} {
     margin: 0.75em 0;
     font-size: 0.85em;
-  }
-  @media ${devices.largeScreen} {
-    font-size: 1em;
-    margin: 1em 0;
   }
 `;
 

--- a/components/CircleContainer/Video.tsx
+++ b/components/CircleContainer/Video.tsx
@@ -5,7 +5,7 @@ import { devices } from "../../utils/cssBreakpoints";
 
 const StyledImg = styled.img`
   position: relative;
-  display: ${({ isVideoLoaded }) => isVideoLoaded ? "none" : "block"};
+  display: ${({ isVideoLoaded }) => (isVideoLoaded ? "none" : "block")};
   height: 100%;
   margin: 0 auto;
   z-index: 1;
@@ -13,6 +13,13 @@ const StyledImg = styled.img`
     position: absolute;
     height: auto;
     bottom: 0;
+  }
+  @media ${devices.largeScreen} {
+    position: absolute;
+    height: 100%;
+    margin: auto;
+    left: 50%;
+    transform: translate(-50%, 0);
   }
 `;
 
@@ -26,6 +33,13 @@ const StyledVideo = styled.video`
     position: absolute;
     height: auto;
     bottom: 0;
+  }
+  @media ${devices.largeScreen} {
+    position: absolute;
+    height: 100%;
+    margin: auto;
+    left: 50%;
+    transform: translate(-50%, 0);
   }
 `;
 

--- a/components/Projects/Project.tsx
+++ b/components/Projects/Project.tsx
@@ -37,6 +37,9 @@ const ProjectContainer = styled(motion.div)`
   @media ${devices.mobileLandscape} {
     font-size: 0.875rem;
   }
+  @media ${devices.largeScreen} {
+    font-size: 1rem;
+  }
 `;
 
 const ProjectOverview = styled.div`

--- a/components/SharedComponents/Pill.tsx
+++ b/components/SharedComponents/Pill.tsx
@@ -1,5 +1,4 @@
 import styled from "styled-components";
-import { ReactElement } from "react";
 
 const PillContainer = styled.div`
   height: 1.75em;

--- a/components/SkillsSection.tsx
+++ b/components/SkillsSection.tsx
@@ -7,6 +7,12 @@ const SkillsContainer = styled.div`
   flex-direction: column;
   justify-content: space-around;
   height: 100%;
+  @media ${devices.mobileLandscape} {
+    font-size: 1.125em;
+  }
+  @media ${devices.largeScreen} {
+    font-size: 1.25em;
+  }
 `;
 
 const Headline = styled.h2`
@@ -14,18 +20,13 @@ const Headline = styled.h2`
   font-weight: 600;
   margin: 0;
   padding: 0;
-  @media ${devices.mobileLandscape} {
-    font-size: 2.25em;
-  }
 `;
 
 const Info = styled.p`
-  font-size: 0.825em;
+  font-size: 0.875em;
+  line-height: 1.5em;
   margin: 0;
   padding: 0;
-  @media ${devices.mobileLandscape} {
-    font-size: 0.85em;
-  }
 `;
 
 const TechContainer = styled.div`

--- a/utils/cssBreakpoints.tsx
+++ b/utils/cssBreakpoints.tsx
@@ -3,6 +3,7 @@ const size = {
   tabletPortrait: "768px",
   tabletLandscape: "1024px",
   laptop: "1280px",
+  largeScreen: "1400px"
 };
 
 export const devices = {
@@ -10,4 +11,5 @@ export const devices = {
   tabletPortrait: `(min-width: ${size.tabletPortrait})`,
   tabletLandscape: `(min-width: ${size.tabletLandscape})`,
   laptop: `(min-width: ${size.laptop})`,
+  largeScreen: `(min-width: ${size.largeScreen})`,
 };


### PR DESCRIPTION
### Purpose 
- Style site to work on largeScreen displays using media queries

### Validating
Mobile and laptop should continue to look/work fine, in screens 1400px+ width, the display should adjust to ensure the following:
- Video/Images inside the circle when a project is expanded are 100% height and centered
- Font size increases without overflowing
- Make sure to check portfolio, skills, and about routes

### Question
- A bit concerned that the pills in /skills will overflow into nav on mobile, based on a quick look at chrome devtools mobile display. Need to check that after deploy and hotfix if needed.